### PR TITLE
Fix crash in Vulkan

### DIFF
--- a/Plugins/TemaranShaderTutorial/Source/ShaderDeclarationDemo/Private/PixelShaderExample.cpp
+++ b/Plugins/TemaranShaderTutorial/Source/ShaderDeclarationDemo/Private/PixelShaderExample.cpp
@@ -130,9 +130,9 @@ void FPixelShaderExample::DrawToRenderTarget_RenderThread(FRHICommandListImmedia
 	// Draw
 	RHICmdList.SetStreamSource(0, GSimpleScreenVertexBuffer.VertexBufferRHI, 0);
 	RHICmdList.DrawPrimitive(0, 2, 1);
-	
-	// Resolve render target
-	RHICmdList.CopyToResolveTarget(DrawParameters.RenderTarget->GetRenderTargetResource()->GetRenderTargetTexture(), DrawParameters.RenderTarget->GetRenderTargetResource()->TextureRHI, FResolveParams());
 
 	RHICmdList.EndRenderPass();
+
+	// Resolve render target
+	RHICmdList.CopyToResolveTarget(DrawParameters.RenderTarget->GetRenderTargetResource()->GetRenderTargetTexture(), DrawParameters.RenderTarget->GetRenderTargetResource()->TextureRHI, FResolveParams());
 }

--- a/Plugins/TemaranShaderTutorial/TemaranShaderTutorial.uplugin
+++ b/Plugins/TemaranShaderTutorial/TemaranShaderTutorial.uplugin
@@ -20,13 +20,13 @@
       "Name": "ShaderDeclarationDemo",
       "Type": "Runtime",
       "LoadingPhase": "PostConfigInit",
-      "WhitelistPlatforms": [ "Win64", "Win32" ]
+      "WhitelistPlatforms": [ "Win64", "Win32", "Linux" ]
     },
     {
       "Name": "ShaderUsageDemo",
       "Type": "Runtime",
       "LoadingPhase": "Default",
-      "WhitelistPlatforms": [ "Win64", "Win32" ]
+      "WhitelistPlatforms": [ "Win64", "Win32", "Linux" ]
     }
   ]
 }


### PR DESCRIPTION
Resolve operations must be done after EndRenderPass, not before.
Fixes Temaran/UE4ShaderPluginDemo#15
Additionally, whitelist Linux platform (tested and working!)

Proof of working in Linux using the Vulkan backend:

![Screenshot_2020-02-29_17-35-49](https://user-images.githubusercontent.com/3395130/75614796-30408200-5b1b-11ea-875c-e84ad0af6028.jpg)
